### PR TITLE
fix: upgrade aws-actions/configure-aws-credentials to v6.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
       uv --version
 
   - name: Configure AWS Credentials (OIDC)
-    uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+    uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
     with:
       role-to-assume: ${{ inputs.aws_role_arn }}
       role-session-name: bedrock-pr-analyzer


### PR DESCRIPTION
addresses the following vuln: https://security.snyk.io/vuln/SNYK-JS-FASTXMLPARSER-15155603